### PR TITLE
Change to using environment variable to get the java client path

### DIFF
--- a/pyspecchio/specchio_connect.py
+++ b/pyspecchio/specchio_connect.py
@@ -4,6 +4,8 @@ to the SPECCHIO API
 """
 
 import jpype as jp
+import sys
+import os
 
 def init_jvm(jvmpath=None):
     """
@@ -11,7 +13,13 @@ def init_jvm(jvmpath=None):
     """
     if jp.isJVMStarted():
         return
-    jp.startJVM(jp.getDefaultJVMPath(), "-ea", "-Djava.class.path=/usr/local/SPECCHIO/specchio-client.jar")
+    try:
+        client_java_path = os.environ['SPECCHIO_JAVA_CLIENT']
+        client_java_argument = "-Djava.class.path=" + client_java_path
+        jp.startJVM(jp.getDefaultJVMPath(), "-ea", client_java_argument)
+    except Exception as exc:
+        print(exc)
+        sys.exit(1)
 
 init_jvm()
 

--- a/pyspecchio/specchio_db_interface.py
+++ b/pyspecchio/specchio_db_interface.py
@@ -6,6 +6,7 @@ Created on Mon Feb 26 09:54:34 2018
 @author: Declan Valters
 """
 import os
+import sys
 
 import jpype as jp
 import numpy as np
@@ -21,9 +22,13 @@ def init_jvm(jvmpath=None):
     """
     if jp.isJVMStarted():
         return
-    jp.startJVM(
-        jp.getDefaultJVMPath(), "-ea",
-        "-Djava.class.path=/usr/local/SPECCHIO/specchio-client.jar")
+    try:
+        client_java_path = os.environ['SPECCHIO_JAVA_CLIENT']
+        client_java_argument = "-Djava.class.path=" + client_java_path
+        jp.startJVM(jp.getDefaultJVMPath(), "-ea", client_java_argument)
+    except Exception as exc:
+        print(exc)
+        sys.exit(1)
 
 init_jvm()
 

--- a/pyspecchio/specchio_upload_test.py
+++ b/pyspecchio/specchio_upload_test.py
@@ -8,7 +8,13 @@ def init_jvm(jvmpath=None):
     """
     if jp.isJVMStarted():
         return
-    jp.startJVM(jp.getDefaultJVMPath(), "-ea", "-Djava.class.path=/usr/local/SPECCHIO/specchio-client.jar")
+    try:
+        client_java_path = os.environ['SPECCHIO_JAVA_CLIENT']
+        client_java_argument = "-Djava.class.path=" + client_java_path
+        jp.startJVM(jp.getDefaultJVMPath(), "-ea", client_java_argument)
+    except Exception as exc:
+        print(exc)
+        sys.exit(1)
 
 init_jvm()
 


### PR DESCRIPTION
Uses the envinroment variable `SPECCHIO_JAVA_CLIENT` now to set the location of the SPECCHIO java client `specchio-client.jar`, once it has been installed. 